### PR TITLE
Fixes 'Cannot access admin manageUsers page'

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -160,6 +160,20 @@ exports.initUser = functions.https.onCall(async (data, context) => {
     await initAccess(user)
 })
 
+exports.initInvalidUsers = functions.https.onRequest(async (request, response) => {
+    let usersResult = await admin.auth().listUsers()
+    let n = 0
+    for(let u of usersResult.users) {
+        // console.log(u.id, u.customClaims)
+        if(!u.customClaims || !u.customClaims.stripeId || !u.customClaims.expirationDate) {
+            n += 1
+            initAccess(u)
+        }
+    }
+
+    response.json({count: n});
+})
+
 exports.initAccess = functions.auth.user().onCreate(initAccess);
 
 async function initAccess(user) {

--- a/src/forAdmin/manageUsers.js
+++ b/src/forAdmin/manageUsers.js
@@ -53,9 +53,10 @@ export default function ManageUsers(props) {
 
 function UserRow(props) {
     let user = _.cloneDeep(props.user)
+    user.customClaims = user.customClaims || {expirationDate: null}
     let claims = user.customClaims
     let [changed, setChanged] = useState(false)
-    console.log(`update user row for ${user.displayName}`)
+    console.log('user', user)
 
     let defaultDateStr = new Date(claims.expirationDate).toISOString().split('T')[0]
     let datePhase = claims.expirationDate - new Date(defaultDateStr).valueOf()
@@ -68,6 +69,8 @@ function UserRow(props) {
 
     let getUpdated = ()=>{
         let newUser = _.cloneDeep(props.user)
+        newUser.customClaims = user.customClaims || {}
+        
         newUser.customClaims.stripeId = stripeRef.current.value || user.customClaims.stripeId
         newUser.customClaims.expirationDate = datePhase + new Date(expirationRef.current.value).valueOf()
 
@@ -150,7 +153,7 @@ function MemoryPowerEditor(props) {
 
         return m
     }, {})
-    console.log(`ALL power for ${props.displayName}`, allPower)
+    // console.log(`ALL power for ${props.displayName}`, allPower)
 
     // submit / cancel modal
     let cancel = ()=>{


### PR DESCRIPTION
Fixes this with two parts:
- makes manageUsers page robust to missing user claims
- adds a cloud function to fix invalid user claims

The source of the uninitialized users was fixed separately by reinstating the firebase blaze plan.