### PR TITLE
Fix password reset mechanism on login page

### DIFF
--- a/src/common/Login.js
+++ b/src/common/Login.js
@@ -38,6 +38,10 @@ function LoginForm(props) {
         if (e.code === 'auth/wrong-password') {
             msg = 'Invalid Password.'
         }
+        if (e.code === 'auth/user-not-found') {
+            // Original message: "There is no user record corresponding to this identifier. The user may have been deleted."
+            msg = 'There is no user registered with that email address.'
+        }
 
         console.log(e);
         setErrorMessage(msg);
@@ -139,28 +143,30 @@ function LoginForm(props) {
             </Card.Text>
             {
                 showResetPassword &&
-                <Card.Text id="resetPassword" className="p-1 text-center">
-                    Having Trouble?
-                    <a href="" className="mx-1" onClick={
-                        function () {
-                            let email = emailRef.current.value;
+                <Card.Text as='div'>
+                    <div className="d-flex flex-centered">
+                        <button type="button" className="btn btn-round btn-secondary m-1" onClick={
+                            function() {
+                                let email = emailRef.current.value;
 
-                            if (!validEmail(email)) {
-                                setErrorToDisplay("Please enter a valid email.")
+                                if (!validEmail(email)) {
+                                    setErrorToDisplay("Please enter a valid email.")
+                                }
+                                else {
+                                    firebase.auth().sendPasswordResetEmail(emailRef.current.value)
+                                        .then(function () {
+                                            // User has been sent a password reset email with a link to do the reset.
+                                            setInfoMessage("You should receive a password reset email within the next 5 minutes. Follow the instructions inside to reset your password, then try logging in with your new password. If you don't receive an email in the next 5 minutes, try clicking Reset Password again.");
+                                            setErrorMessage("");
+                                        })
+                                        .catch((errorMsg) => {
+                                            // Error occurred trying to reset email.
+                                            setErrorToDisplay(errorMsg);
+                                        });
+                                }
                             }
-                            else {
-                                firebase.auth().sendPasswordResetEmail(emailRef.current.value)
-                                    .then(function () {
-                                        // User has been sent a password reset email with a link to do the reset.
-                                        setInfoMessage("Password reset email has been sent and should arrive in the next 5 minutes. Follow the instructions inside to reset your password, then try logging in with your new password. If you don't receive an email in the next 5 minutes, try clicking Reset Password again.");
-                                    })
-                                    .catch((errorMsg) => {
-                                        // Error occurred trying to reset email.
-                                        setErrorToDisplay(errorMsg);
-                                    });
-                            }
-                        }
-                    }>Reset Password</a>
+                        } >Reset Password</button>
+                    </div>
                 </Card.Text>
             }
             {/* Place the info message below the Password Reset button because it's an info message informing of password reset success.*/}

--- a/src/common/Login.js
+++ b/src/common/Login.js
@@ -119,9 +119,6 @@ function LoginForm(props) {
     }
     
     let title = 'Sign In / Create Account' // action=='signin' ? 'Sign In' : 'Create Account'
-    window.onbeforeunload = function () {
-        return "";
-    }
 
     return <Card {...props} className={'small-card '+(props.className||'')} >
         <Card.Title as='h3' className='mt-3 text-center'>

--- a/src/common/Login.js
+++ b/src/common/Login.js
@@ -24,16 +24,21 @@ function validEmail(email) {
 function LoginForm(props) {
     const [showResetPassword, setShowResetPassword] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
+    const [infoMessage, setInfoMessage] = useState("");
     const [action, setAction] = useState('signin')
 
     const emailRef = useRef()
     const pwdRef = useRef()
     const nameRef = useRef()
 
-    function error(e) {
+    function setErrorToDisplay(e) {
         let msg = e.message || e
+
         // Change some error messages
-        if(e.code === 'auth/wrong-password') msg = 'Invalid Password.'
+        if (e.code === 'auth/wrong-password') {
+            msg = 'Invalid Password.'
+        }
+
         console.log(e);
         setErrorMessage(msg);
     }
@@ -60,16 +65,16 @@ function LoginForm(props) {
 
         // validate input
         if(!validEmail(email))
-            error("Please enter a valid email.")
+            setErrorToDisplay("Please enter a valid email.")
         else if (password.length === 0)
-            error("Please enter password.")
+            setErrorToDisplay("Please enter password.")
         else if (name.length === 0)
-            error("Please enter your name.")
+            setErrorToDisplay("Please enter your name.")
         else {
             // console.log('create account', email, name, password.replaceAll(/./g, '*'))
 
-            await auth.createUserWithEmailAndPassword(email, password).catch(error)
-            await firebase.auth().currentUser.updateProfile({displayName: name}).catch(error)
+            await auth.createUserWithEmailAndPassword(email, password).catch(setErrorToDisplay)
+            await firebase.auth().currentUser.updateProfile({ displayName: name }).catch(setErrorToDisplay)
             await initUser().then(setTimeout(()=>window.location.reload(), 100))
         }
     }
@@ -84,7 +89,7 @@ function LoginForm(props) {
             .then(props.onSubmit)
             .catch(e => {
                 setShowResetPassword(true)
-                error(e)
+                setErrorToDisplay(e)
             })
 
         userDataMigration()
@@ -110,6 +115,9 @@ function LoginForm(props) {
     }
     
     let title = 'Sign In / Create Account' // action=='signin' ? 'Sign In' : 'Create Account'
+    window.onbeforeunload = function () {
+        return "";
+    }
 
     return <Card {...props} className={'small-card '+(props.className||'')} >
         <Card.Title as='h3' className='mt-3 text-center'>
@@ -129,12 +137,36 @@ function LoginForm(props) {
                 </div>
                 <div id="error-message" className="text-danger py-2">{errorMessage}</div>
             </Card.Text>
-            {showResetPassword && <Card.Text id="resetPassword" className="p-1 text-center">
-                Having Trouble?
-                <a href="" className="mx-1" onClick={() =>
-                    auth.sendPasswordResetPassword($("#email").val()).catch(error) // TODO set better response message
-                }>Reset Password</a>
-            </Card.Text>}
+            {
+                showResetPassword &&
+                <Card.Text id="resetPassword" className="p-1 text-center">
+                    Having Trouble?
+                    <a href="" className="mx-1" onClick={
+                        function () {
+                            let email = emailRef.current.value;
+
+                            if (!validEmail(email)) {
+                                setErrorToDisplay("Please enter a valid email.")
+                            }
+                            else {
+                                firebase.auth().sendPasswordResetEmail(emailRef.current.value)
+                                    .then(function () {
+                                        // User has been sent a password reset email with a link to do the reset.
+                                        setInfoMessage("Password reset email has been sent and should arrive in the next 5 minutes. Follow the instructions inside to reset your password, then try logging in with your new password. If you don't receive an email in the next 5 minutes, try clicking Reset Password again.");
+                                    })
+                                    .catch((errorMsg) => {
+                                        // Error occurred trying to reset email.
+                                        setErrorToDisplay(errorMsg);
+                                    });
+                            }
+                        }
+                    }>Reset Password</a>
+                </Card.Text>
+            }
+            {/* Place the info message below the Password Reset button because it's an info message informing of password reset success.*/}
+            <Card.Text as='div'>
+                <div id="info-message" className="p-1 text">{infoMessage}</div>
+            </Card.Text>
         </Card.Body>
         <Card.Footer >
             <a href={tosUrl} className="p-1">Terms of Service</a>


### PR DESCRIPTION
Our current password reset button doesn't work at all (sends no email and refreshes the page). This change does the following:
- Changes the link to a button. This prevents the page from getting refreshed so we can display a success or error message to the user informing them if the password reset succeeded, and what to do next.
- Call the correct firebase auth function to send password reset email and display info message to user that email has been sent.
- Display user-friendly error message when user tries to reset password for an email that is not registered.

Here is a short video showing the new Password Reset flow:
https://www.dropbox.com/s/fv7iu1uui634d7x/Password%20Reset%20Flow.mp4?dl=0

Tested manually with my accounts and can confirm that it works.