### PR TITLE
Add .vs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .idea
 .firebase/*.cache
 .vscode/*
+.vs/*
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
.vs are files generated by visual studio that should not be committed.