### PR TITLE
Fix 404 error after Stripe checkout - correct success_url and cancel_url for Stripe sessions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -142,8 +142,8 @@ exports.createCheckoutSession = functions.https.onCall(async (data, context) => 
         subscription_data: {
             items: data.items
         },
-        success_url: 'https://bythebookthebible.com/memorize',
-        cancel_url: 'https://bythebookthebible.com/subscribe',
+        success_url: "https://schmudgin.bythebookthebible.com",
+        cancel_url: "https://schmudgin.bythebookthebible.com"
     }
     const session = await stripe.checkout.sessions.create(options).catch(e => {
         console.error('Error Creating Stripe Session: ', JSON.stringify(e))


### PR DESCRIPTION
This change corrects the 404 error users have reported seeing after going through Stripe subscription checking by correcting the success_url and cancel_url parameters in our Stripe checkout session creation call.

TBD: testing - since these are changes to a cloud function, I'm not yet sure how to test them locally. May need to look into the firebase emulation thing.